### PR TITLE
Fix broken ko-fi donation icon in header component

### DIFF
--- a/spec/broken-icon-fix-plan.md
+++ b/spec/broken-icon-fix-plan.md
@@ -1,0 +1,31 @@
+# Fix Broken Ko-fi Icon Plan
+
+## Problem Analysis
+The broken icon is located in `/src/app/header/header.component.html` at lines 5-7. It's a "Buy Me a Coffee" ko-fi icon that uses an external image URL (`https://az743702.vo.msecnd.net/cdn/kofi2.png?v=b`) that is no longer accessible.
+
+## Solution Options
+
+### Option 1: Update to Official Ko-fi Button (Recommended)
+- Replace the broken external image URL with the current official Ko-fi button image
+- Use the current Ko-fi CDN URL: `https://cdn.ko-fi.com/cdn/kofi2.png?v=3`
+
+### Option 2: Remove the Ko-fi Button
+- Remove the entire ko-fi donation section if no longer needed
+
+### Option 3: Add Local Asset
+- Download the ko-fi icon and store it locally in the assets folder
+- Update the image source to point to the local asset
+
+## Implementation Steps (Option 1 - Recommended)
+1. Update the image `src` attribute in `header.component.html` line 6
+2. Change from: `https://az743702.vo.msecnd.net/cdn/kofi2.png?v=b`
+3. Change to: `https://cdn.ko-fi.com/cdn/kofi2.png?v=3`
+4. Test the fix by running the development server
+
+## Files to Modify
+- `/src/app/header/header.component.html` (line 6)
+
+This is a simple one-line fix that should resolve the broken icon issue immediately.
+
+## Implementation Status
+✅ **COMPLETED** - Updated the ko-fi icon URL in header component from broken URL to current official Ko-fi CDN URL.

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -3,7 +3,7 @@
     <h3>Browse any archived playlist before saving to your account</h3>
     <div>
         <a href="https://ko-fi.com/A1439LK" target="_blank"><img height="32" style="border:0px;height:32px;"
-                src="https://az743702.vo.msecnd.net/cdn/kofi2.png?v=b" border="0"
+                src="https://cdn.ko-fi.com/cdn/kofi2.png?v=3" border="0"
                 alt="Buy Me a Coffee at ko-fi.com"></a>
     </div>
 </div>


### PR DESCRIPTION
Updated ko-fi icon URL from deprecated Microsoft CDN to current official ko-fi CDN. The old URL (az743702.vo.msecnd.net) was returning broken images, now using cdn.ko-fi.com with latest version.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
