### PR TITLE
Prevent duplicate playlists with a unique index

### DIFF
--- a/server/lib/sync.js
+++ b/server/lib/sync.js
@@ -114,7 +114,7 @@ export function startSync() {
   console.log('Starting initial sync...');
   sync();
 
-  cron.schedule('0 */2 * * *', () => {
+  cron.schedule('0 */8 * * *', () => {
     console.log('Running scheduled sync...');
     sync();
   });

--- a/server/models/playlist.js
+++ b/server/models/playlist.js
@@ -19,6 +19,7 @@ const playlistSchema = new mongoose.Schema({
 });
 
 playlistSchema.index({ region: 1, published_date: -1 });
+playlistSchema.index({ title: 1, region: 1 }, { unique: true });
 
 const Playlist = mongoose.model('Playlist', playlistSchema);
 


### PR DESCRIPTION
## Problem

The site showed two cards with the same date (e.g. two `New.Music.Friday.US.05.15.2026`) — one holding the current week's tracks, the other a frozen copy of the previous week's.

## Root cause

Sync upserts on `{ title, region }`, but the schema had **no unique index**. `startSync()` runs an immediate `sync()` on boot and the cron also fires on the hour. When a deploy/restart lands at the top of an hour, two `sync()` calls run `findOneAndUpdate(..., upsert: true)` concurrently, neither finds an existing doc, and **both insert** — yielding two docs with byte-identical title/region but adjacent ObjectIds. Later upserts update only one, leaving the other stale. Confirmed from live data (stale duplicate's track `created` predates the live one by days).

## Fix

- Add a unique compound index on `{ title, region }`. The losing concurrent upsert now fails with `E11000`, which `sync()` already catches and logs — so the race resolves to "one insert wins, the other is a harmless logged error."
- Widen the cron interval 2h → 8h to shrink the collision window.

## Deploy note

⚠️ The unique index cannot build while duplicates still exist. **Existing duplicates must be removed from production before this deploys**, or Mongoose's background index build will silently fail. A separate one-time dedupe script + runbook handle that cleanup (not in this PR).

## Validation

The dedupe approach was validated locally against a real production backup: restored 1177 docs, found the 2 known duplicate groups, kept the current-week doc, deleted the stale copies (1177 → 1175), then built the unique index successfully and confirmed a duplicate insert is rejected with E11000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)