### PR TITLE
Fix expanded playlist clipping past 26 tracks (#156)

### DIFF
--- a/client/src/components/PlaylistCard.jsx
+++ b/client/src/components/PlaylistCard.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useRef, useLayoutEffect } from 'react';
 import TrackItem from './TrackItem';
 import SavePlaylist from './SavePlaylist';
 import PlaylistDownload from './PlaylistDownload';
@@ -34,6 +34,15 @@ function RegionTitle({ title, region }) {
 export default function PlaylistCard({ playlist, index }) {
   const [expanded, setExpanded] = useState(false);
   const [activeTrack, setActiveTrack] = useState(null);
+  const trackListRef = useRef(null);
+  const [maxHeight, setMaxHeight] = useState(0);
+
+  // Measure the real content height so the expand animation never clips long
+  // playlists (a fixed max-height cap clipped lists past ~26 tracks — issue #156).
+  useLayoutEffect(() => {
+    if (!trackListRef.current) return;
+    setMaxHeight(expanded ? trackListRef.current.scrollHeight : 0);
+  }, [expanded, playlist.tracks.length]);
 
   const waveformBars = useMemo(() => generateWaveformBars(), []);
 
@@ -82,7 +91,7 @@ export default function PlaylistCard({ playlist, index }) {
           <path d="M5 7.5 L10 12.5 L15 7.5" />
         </svg>
       </div>
-      <div className="track-list">
+      <div className="track-list" ref={trackListRef} style={{ maxHeight }}>
         <div className="track-list-inner">
           {playlist.tracks.map((track, i) => (
             <TrackItem

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -640,9 +640,8 @@ h1, h2, h3 {
   transition: max-height 0.5s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.playlist-card.expanded .track-list {
-  max-height: 2000px;
-}
+/* Expanded max-height is set inline from the measured scrollHeight in
+   PlaylistCard.jsx so long playlists never clip (issue #156). */
 
 .track-list-inner {
   padding: 0 24px 20px;


### PR DESCRIPTION
Fixes #156.

## Problem

Expanding a playlist card only revealed the first ~26 of 100+ tracks. The `.track-list` expand/collapse animation transitioned `max-height` from `0` to a fixed `2000px` cap with `overflow: hidden`. A New Music Friday playlist (~100+ tracks) is ~7800px tall, so everything past the cap was clipped.

## Fix

Measure the list's real `scrollHeight` in a `useLayoutEffect` and set `max-height` inline on expand (back to `0` on collapse), keyed on `expanded` and track count. The CSS transition still drives the animation; it just never clips at any track count. Removed the obsolete `2000px` cap from `index.css`.

This is more robust than bumping the magic number — it fits exactly regardless of list size.

## Verification

Verified live in a browser against a 101-track UK playlist (agent-browser). Computed geometry confirmed the fix:

| | Before (cap) | After (fix) |
|---|---|---|
| `max-height` | `2000px` | `7816px` (measured) |
| `clientHeight` vs `scrollHeight` | 2000 vs 7816 | 7816 vs 7816 |
| `clipped` | true | **false** |
| last track within list | no | **yes** |

The last track and the "Save playlist to Spotify" block render fully. `bun run build` passes.

Note: no automated test added — this is a pure CSS layout clip and the client has no test runner; JSDOM doesn't compute layout (`scrollHeight` is always 0), so a unit test couldn't observe the bug. A Playwright test could guard it in CI if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)