### PR TITLE
Handle Spotify 6-month refresh token expiration

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2,6 +2,7 @@ import { RegionProvider } from './hooks/useRegion';
 import { SpotifyAuthProvider } from './hooks/useSpotifyAuth';
 import MeshBackground from './components/MeshBackground';
 import Header from './components/Header';
+import SessionExpiredBanner from './components/SessionExpiredBanner';
 import Hero from './components/Hero';
 import PlaylistList from './components/PlaylistList';
 import Footer from './components/Footer';
@@ -14,6 +15,7 @@ export default function App() {
         <div className="grain" aria-hidden="true" />
         <div className="page">
           <Header />
+          <SessionExpiredBanner />
           <Hero />
           <main className="archive">
             <PlaylistList />

--- a/client/src/components/SessionExpiredBanner.jsx
+++ b/client/src/components/SessionExpiredBanner.jsx
@@ -1,0 +1,32 @@
+import { useSpotifyAuth } from '../hooks/useSpotifyAuth';
+
+export default function SessionExpiredBanner() {
+  const { sessionExpired, login, dismissSessionExpired, loading } = useSpotifyAuth();
+
+  if (!sessionExpired) return null;
+
+  return (
+    <div className="session-banner" role="alert">
+      <div className="session-banner-inner">
+        <span className="session-banner-text">
+          Your Spotify session expired — please sign in again.
+        </span>
+        <div className="session-banner-actions">
+          <button className="session-banner-signin" onClick={login} disabled={loading}>
+            Sign in
+          </button>
+          <button
+            className="session-banner-dismiss"
+            onClick={dismissSessionExpired}
+            aria-label="Dismiss notification"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/hooks/useSpotifyAuth.jsx
+++ b/client/src/hooks/useSpotifyAuth.jsx
@@ -37,6 +37,10 @@ export function SpotifyAuthProvider({ children }) {
   });
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(false);
+  // True when a refresh failed because the 6-month refresh token expired/was revoked,
+  // so the UI can prompt the user to sign in again. Cleared on a successful sign-in
+  // or a deliberate sign-out.
+  const [sessionExpired, setSessionExpired] = useState(false);
 
   const isAuthenticated = !!accessToken && Date.now() < expiresAt;
 
@@ -45,6 +49,7 @@ export function SpotifyAuthProvider({ children }) {
     setAccessToken(access);
     setRefreshToken(refresh);
     setExpiresAt(expiry);
+    setSessionExpired(false);
     sessionStorage.setItem(TOKEN_KEY, access);
     if (refresh) sessionStorage.setItem(REFRESH_KEY, refresh);
     sessionStorage.setItem(EXPIRES_KEY, String(expiry));
@@ -60,6 +65,8 @@ export function SpotifyAuthProvider({ children }) {
     sessionStorage.removeItem(EXPIRES_KEY);
   }, []);
 
+  const dismissSessionExpired = useCallback(() => setSessionExpired(false), []);
+
   const refreshAccessToken = useCallback(async () => {
     if (!refreshToken) return;
     try {
@@ -68,7 +75,13 @@ export function SpotifyAuthProvider({ children }) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ refresh_token: refreshToken }),
       });
-      if (!res.ok) throw new Error('Refresh failed');
+      if (!res.ok) {
+        // Spotify returns invalid_grant once the 6-month refresh token expires.
+        // Do not retry — discard the token and prompt the user to sign in again.
+        const data = await res.json().catch(() => ({}));
+        if (data?.error === 'invalid_grant') setSessionExpired(true);
+        throw new Error('Refresh failed');
+      }
       const data = await res.json();
       storeTokens(data.access_token, data.refresh_token || refreshToken, data.expires_in);
     } catch {
@@ -158,7 +171,7 @@ export function SpotifyAuthProvider({ children }) {
     return () => clearTimeout(timer);
   }, [expiresAt, refreshToken, refreshAccessToken]);
 
-  const value = { user, isAuthenticated, loading, login, logout, accessToken };
+  const value = { user, isAuthenticated, loading, login, logout, accessToken, sessionExpired, dismissSessionExpired };
 
   return (
     <SpotifyAuthContext.Provider value={value}>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -120,6 +120,87 @@ body {
   flex-wrap: wrap;
 }
 
+/* --- Session expired banner --- */
+.session-banner {
+  position: sticky;
+  top: 14px;
+  z-index: 49;
+  max-width: 1180px;
+  margin: 14px auto 0;
+  padding: 0 32px;
+}
+
+.session-banner-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  padding: 12px 16px 12px 22px;
+  border-radius: 22px;
+  overflow: hidden;
+  backdrop-filter: blur(20px) saturate(1.5);
+  -webkit-backdrop-filter: blur(20px) saturate(1.5);
+  background: linear-gradient(100deg, rgba(124, 92, 255, 0.4), rgba(255, 78, 205, 0.4));
+  border: 1px solid rgba(255, 120, 220, 0.5);
+  box-shadow: inset 4px 0 0 var(--c-magenta), 0 10px 36px rgba(255, 78, 205, 0.3);
+}
+
+.session-banner-text {
+  font-size: 0.94rem;
+  color: #fff;
+  font-weight: 600;
+}
+
+.session-banner-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.session-banner-signin {
+  padding: 7px 20px;
+  border-radius: 999px;
+  border: none;
+  background: #fff;
+  color: #1a0b2e;
+  font-family: var(--font-body);
+  font-weight: 700;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: box-shadow 0.2s var(--ease-smooth), transform 0.2s var(--ease-spring);
+}
+
+.session-banner-signin:hover {
+  box-shadow: 0 0 18px rgba(255, 255, 255, 0.55);
+  transform: translateY(-1px);
+}
+
+.session-banner-signin:disabled {
+  opacity: 0.5;
+  cursor: default;
+  transform: none;
+}
+
+.session-banner-dismiss {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.75);
+  cursor: pointer;
+  transition: color 0.2s var(--ease-smooth), background 0.2s var(--ease-smooth);
+}
+
+.session-banner-dismiss:hover {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.15);
+}
+
 .brand {
   display: flex;
   align-items: center;

--- a/server/controllers/spotify.js
+++ b/server/controllers/spotify.js
@@ -70,6 +70,11 @@ export async function refreshToken(req, res) {
 
     if (!response.ok) {
       console.error('Spotify token refresh error:', data);
+      // A 6-month-expired or revoked refresh token returns invalid_grant.
+      // Surface it distinctly so the client can prompt re-authorization (do not retry).
+      if (data?.error === 'invalid_grant') {
+        return res.status(response.status).json({ error: 'invalid_grant' });
+      }
       return res.status(response.status).json({ error: 'Token refresh failed' });
     }
 

--- a/server/controllers/spotify.test.js
+++ b/server/controllers/spotify.test.js
@@ -176,17 +176,31 @@ describe('refreshToken', () => {
     });
   });
 
-  it('handles Spotify error responses', async () => {
+  it('surfaces invalid_grant distinctly when the refresh token is expired/revoked', async () => {
     fetch.mockResolvedValueOnce({
       ok: false,
       status: 400,
       json: async () => ({ error: 'invalid_grant' }),
     });
 
-    const { req, res } = mockReqRes({ refresh_token: 'bad-rt' });
+    const { req, res } = mockReqRes({ refresh_token: 'expired-rt' });
     await refreshToken(req, res);
 
     expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'invalid_grant' }));
+  });
+
+  it('returns a generic error for non-invalid_grant Spotify errors', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: 'server_error' }),
+    });
+
+    const { req, res } = mockReqRes({ refresh_token: 'some-rt' });
+    await refreshToken(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
     expect(res.json).toHaveBeenCalledWith({ error: 'Token refresh failed' });
   });
 });


### PR DESCRIPTION
## Context

Spotify announced ([blog 2026-06-18](https://developer.spotify.com/blog/2026-06-18-refresh-token-expiration)) that **refresh tokens now expire 6 months after the user's initial authorization** — previously they were indefinite. Enforcement for existing apps begins **2026-07-20**. When a refresh token expires or is revoked, the token endpoint returns an `invalid_grant` error, which must **not** be retried — the stored token should be discarded and the user routed back through sign-in.

The token *mechanics* were already largely compliant (backend returns new refresh tokens, frontend persists them, refresh failures call `logout()`). The real gap was that an expired session **silently logged the user out with no explanation**.

## Changes

- **Backend** (`server/controllers/spotify.js`): `refreshToken` now surfaces `invalid_grant` distinctly (was a generic `Token refresh failed`) so the client can react deterministically. No retry logic; other upstream errors keep the sanitized generic response.
- **Frontend** (`client/src/hooks/useSpotifyAuth.jsx`): added a `sessionExpired` signal, set **only** on the `invalid_grant` refresh path and cleared on a successful sign-in. A deliberate sign-out never triggers it.
- **UI** (`client/src/components/SessionExpiredBanner.jsx` + styles): a dismissible glass banner — "Your Spotify session expired — please sign in again." — with Sign in / dismiss actions, matching the Liquid Audio theme (22px radius like the playlist cards).

Scope is the **refresh path only** (the sole place a refresh token is used); no API-401 handling and no server-side token storage.

## Testing

- TDD on the backend: tests written first and watched fail, then implemented. **44/44 backend tests pass.**
- Verified end-to-end via agent-browser against the live Spotify API (real `invalid_grant`):
  - Expired refresh → banner appears, tokens discarded, no retry
  - Sign in / dismiss controls work
  - Deliberate sign-out shows **no** banner
- Client builds clean.

> Note for local manual testing: open the prod build at `http://127.0.0.1:3000` (not `localhost`) — `.env` `ALLOWED_ORIGINS` only allows `127.0.0.1`, so `localhost` browser API calls are blocked by CORS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)